### PR TITLE
add support for pydantic and returning models that can be converted to a dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ async def home_post(request: Request):
     person = Person(**form)
 
     return person # Person(id=1, name='Jane')
+
 ```
 
 If a `fastapi.Response` is returned, the template is skipped and the response along with status_code and

--- a/README.md
+++ b/README.md
@@ -56,13 +56,32 @@ from fastapi_jinja import template
 @template('home/index.j2')
 async def home_post(request: Request):
     form = await request.form()
-    vm = PersonViewModel(**form) 
+    vm = PersonViewModel(**form)
 
     return vm.dict() # {'first':'John', 'last':'Doe', ...}
 
 ```
 
-The view method should return a `dict` to be passed as variables/values to the template. 
+The view method should return a `dict` to be passed as variables/values to the template.
+We can also return model objects that can be converted into a dictionary, common when using libraries
+such as pydantic to represent models in various forms.
+
+```python
+from fastapi_jinja import template
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    id: int
+    name: str
+
+@router.post("/")
+@template('home/index.j2')
+async def home_post(request: Request):
+    form = await request.form() # form: {'id': 1, 'name': 'Jane'}
+    person = Person(**form)
+
+    return person # Person(id=1, name='Jane')
+```
 
 If a `fastapi.Response` is returned, the template is skipped and the response along with status_code and
 other values is directly passed through. This is common for redirects and error responses not meant

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -14,6 +14,19 @@ folder = os.path.join(here, "templates")
 
 fake_request = Request(scope={'type': 'http'})
 
+class DictModel:
+    """This represents a model that can be converted into a dict, such as pydantic."""
+
+    def __init__(self, name: str, age: int):
+        self.name = name
+        self.age = age
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'age': self.age,
+        }
+
 
 def test_cannot_decorate_missing_template():
     with pytest.raises(TemplateNotFound):
@@ -23,6 +36,17 @@ def test_cannot_decorate_missing_template():
             return {}
 
         view_method(fake_request)
+
+
+def test_can_decorate_with_dictable_response():
+    @fj.template("home/index.j2")
+    def view_method(request: Request, name, age):
+        model = DictModel(name, age)
+        return model.to_dict()
+
+    resp = view_method(fake_request, "foo", 42)
+    assert isinstance(resp, fastapi.Response)
+    assert resp.status_code == 200
 
 
 def test_can_decorate_dict_sync_method():


### PR DESCRIPTION
This is borrowed from one of the other forks, where adding support for returning pydantic models was added. This should allow us to also return a pydantic model,, or any model/object that has support for being converted into a dictionary.

The idea was primarily borrowed from here on another fork.
https://github.com/stevenj/fastapi-jinja/commit/af6a46a17c5471f141c103f2c59fa889b17287c2